### PR TITLE
Updated README.md to consistently name component

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## Install
 
 1. `npm install react-native-draggable-flatlist` or `yarn add react-native-draggable-flatlist`
-2. `import DraggableFlatlist from 'react-native-draggable-flatlist'`  
+2. `import DraggableFlatList from 'react-native-draggable-flatlist'`  
 
 ## Api
 


### PR DESCRIPTION
`DraggableFlatList` was named inconsistently (lower case `l`) which could cause an inadvertent error.