### PR TITLE
Fix for hovered rows after onRelease on Android

### DIFF
--- a/index.js
+++ b/index.js
@@ -392,7 +392,7 @@ class RowItem extends PureComponent {
     })
     // Rendering the final row requires padding to be applied at the bottom
     return (
-      <View ref={setRef(index)} style={{ opacity: 1, flexDirection: horizontal ? 'row' : 'column' }}>
+      <View collapsable={false} ref={setRef(index)} style={{ opacity: 1, flexDirection: horizontal ? 'row' : 'column' }}>
         {!!spacerSize && this.renderSpacer(spacerSize)}
         <View style={[
           horizontal ? { width: isActiveRow ? 0 : undefined } : { height: isActiveRow ? 0 : undefined },


### PR DESCRIPTION
On Android measureInWindow returns undefined width and height. This causes the releaseAnim not to start. 
More Info: 
https://github.com/facebook/react-native/issues/9382
https://facebook.github.io/react-native/docs/view.html#collapsable