### PR TITLE
bugfix: #20 - Drag-and-Drop not working on Android (RN 0.57.0)

### DIFF
--- a/index.js
+++ b/index.js
@@ -392,7 +392,7 @@ class RowItem extends PureComponent {
     })
     // Rendering the final row requires padding to be applied at the bottom
     return (
-      <View ref={setRef(index)} style={{ opacity: 1, flexDirection: horizontal ? 'row' : 'column' }}>
+      <View ref={setRef(index)} collapsable={false} style={{ opacity: 1, flexDirection: horizontal ? 'row' : 'column' }}>
         {!!spacerSize && this.renderSpacer(spacerSize)}
         <View style={[
           horizontal ? { width: isActiveRow ? 0 : undefined } : { height: isActiveRow ? 0 : undefined },


### PR DESCRIPTION
I found the issue was caused by `this._refs[index].measureInWindow` (in `measureItem` function) providing `undefined` values (x, y, width, height) to the callback.

It seems that this is related to issue [#9382](https://github.com/facebook/react-native/issues/9382) in react-native.

I resolved this issue by setting the [collapsable](https://facebook.github.io/react-native/docs/view.html#collapsable) prop on each row to `false`.
This avoids react-native 'optimization' and ensures the view exists in the view hierarchy, so that measurements can be taken.