### PR TITLE
Remove `overflow: hidden` from View on inside of RowItem

### DIFF
--- a/index.js
+++ b/index.js
@@ -396,7 +396,7 @@ class RowItem extends PureComponent {
         {!!spacerSize && this.renderSpacer(spacerSize)}
         <View style={[
           horizontal ? { width: isActiveRow ? 0 : undefined } : { height: isActiveRow ? 0 : undefined },
-          { opacity: isActiveRow ? 0 : 1, overflow: 'hidden' }
+          { opacity: isActiveRow ? 0 : 1 }
         ]}>
           {component}
         </View>


### PR DESCRIPTION
Our rows are cards with drop shadows that get cut off by this style. 
It seems to be fine in a vertical list on iOS. I have not tested on android or with a horizontal list. Is it necessary for either of those cases?