### PR TITLE
clear refs on each render to avoid measurement errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -339,6 +339,8 @@ class SortableFlatList extends Component {
 
   render() {
     const { horizontal, keyExtractor } = this.props
+    this._refs = [];
+
     return (
       <View
         onLayout={e => {


### PR DESCRIPTION
I am using dynamic data and I get a lot of these errors when I am filtering my data that I pass to DraggableFlatlist:
```
## measure error -- index:  3 -1 ...
```

When using dynamic data on a mounted DraggableFlatlist and removing/adding items the `_refs` are not representing the current tree. Because each render will potentially remove items I suggest to clear the refs as these are anyways filled again on each render.

@fixes #17