### PR TITLE
Remove contentContainerStyle from docs and default props

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## Install
 
 1. `npm install react-native-draggable-flatlist` or `yarn add react-native-draggable-flatlist`
-2. `import DraggableFlatList from 'react-native-draggable-flatlist'`  
+2. `import DraggableFlatList from 'react-native-draggable-flatlist'`
 
 ## Api
 
@@ -14,9 +14,8 @@ Props:
 - `horizontal` (boolean) Orientation of list.
 - `renderItem` (Function) `({ item, index, move, moveEnd, isActive }) => <Component />`. Call `move` when the row should become active (in an `onPress`, `onLongPress`, etc). Call `moveEnd` when the gesture is complete (in `onPressOut`).
 - `keyExtractor` (Function) `(item, index) => string`
-- `contentContainerStyle` (Object)
-- `scrollPercent` (Number) Sets where scrolling begins. A value of `5` will scroll up if the finger is in the top 5% of the FlatList container and scroll down in the bottom 5%. 
-- `onMoveEnd` (Function) `({ data, to, from, row }) => void` Returns updated ordering of `data` 
+- `scrollPercent` (Number) Sets where scrolling begins. A value of `5` will scroll up if the finger is in the top 5% of the FlatList container and scroll down in the bottom 5%.
+- `onMoveEnd` (Function) `({ data, to, from, row }) => void` Returns updated ordering of `data`
 - `onMoveBegin` (Function) `(index) => void` Called when row becomes active.
 - All props are spread onto underlying FlatList
 
@@ -41,17 +40,17 @@ class Example extends Component {
   renderItem = ({ item, index, move, moveEnd, isActive }) => {
     return (
       <TouchableOpacity
-        style={{ 
-          height: 100, 
+        style={{
+          height: 100,
           backgroundColor: isActive ? 'blue' : item.backgroundColor,
-          alignItems: 'center', 
-          justifyContent: 'center' 
+          alignItems: 'center',
+          justifyContent: 'center'
         }}
         onLongPress={move}
         onPressOut={moveEnd}
       >
-        <Text style={{ 
-          fontWeight: 'bold', 
+        <Text style={{
+          fontWeight: 'bold',
           color: 'white',
           fontSize: 32,
         }}>{item.label}</Text>
@@ -76,4 +75,3 @@ class Example extends Component {
 
 export default Example
 ```
-

--- a/index.js
+++ b/index.js
@@ -104,7 +104,7 @@ class SortableFlatList extends Component {
         const spacerMeasurements = this._measurements[spacerIndex]
         const lastElementMeasurements = this._measurements[data.length - 1]
 
-        // If user flings row up and lets go in the middle of an animation measurements can error out. 
+        // If user flings row up and lets go in the middle of an animation measurements can error out.
         // Give layout animations some time to complete and animate element into place before calling onMoveEnd
 
         // Spacers have different positioning depending on whether the spacer row is before or after the active row.
@@ -368,7 +368,6 @@ export default SortableFlatList
 
 SortableFlatList.defaultProps = {
   scrollPercent: 5,
-  contentContainerStyle: {},
 }
 
 class RowItem extends PureComponent {


### PR DESCRIPTION
I have checked the library and it seems that `contentContainerStyle` prop is not being used anywhere, maybe it is a good idea to remove it? What do you think @computerjazz.