### PR TITLE
Clear all timeouts when component unmount

### DIFF
--- a/index.js
+++ b/index.js
@@ -349,7 +349,7 @@ class SortableFlatList extends Component {
   }
 
   render() {
-    const { horizontal, keyExtractor, FlatListComponent } = this.props
+    const { horizontal, keyExtractor, FlatListComponent, flatListRef } = this.props
     const List = FlatListComponent || FlatList;
     return (
       <View
@@ -360,7 +360,10 @@ class SortableFlatList extends Component {
         <List
           {...this.props}
           scrollEnabled={this.state.activeRow === -1}
-          ref={ref => this._flatList = ref}
+          ref={ref => {
+            flatListRef(ref)
+            this._flatList = ref
+          }}
           renderItem={this.renderItem}
           extraData={this.state}
           keyExtractor={keyExtractor || this.keyExtractor}

--- a/index.js
+++ b/index.js
@@ -349,17 +349,15 @@ class SortableFlatList extends Component {
   }
 
   render() {
-    const { horizontal, keyExtractor } = this.props
+    const { horizontal, keyExtractor, FlatListComponent } = this.props
+    const List = FlatListComponent || FlatList;
     return (
       <View
-        onLayout={e => {
-          console.log('layout', e.nativeEvent)
-        }}
         ref={this.measureContainer}
         {...this._panResponder.panHandlers}
         style={styles.wrapper} // Setting { opacity: 1 } fixes Android measurement bug: https://github.com/facebook/react-native/issues/18034#issuecomment-368417691
       >
-        <FlatList
+        <List
           {...this.props}
           scrollEnabled={this.state.activeRow === -1}
           ref={ref => this._flatList = ref}

--- a/index.js
+++ b/index.js
@@ -353,6 +353,9 @@ class SortableFlatList extends Component {
     const List = FlatListComponent || FlatList;
     return (
       <View
+        onLayout={e => {
+          console.log('layout', e.nativeEvent)
+        }}
         ref={this.measureContainer}
         {...this._panResponder.panHandlers}
         style={styles.wrapper} // Setting { opacity: 1 } fixes Android measurement bug: https://github.com/facebook/react-native/issues/18034#issuecomment-368417691

--- a/index.js
+++ b/index.js
@@ -364,7 +364,7 @@ class SortableFlatList extends Component {
           {...this.props}
           scrollEnabled={this.state.activeRow === -1}
           ref={ref => {
-            flatListRef(ref)
+            flatListRef && flatListRef(ref)
             this._flatList = ref
           }}
           renderItem={this.renderItem}


### PR DESCRIPTION
When the component is unmounted, these `setTimeout` functions make app freeze. Solution is clear all timeouts in `componentWillUnmount` lifecycle