### PR TITLE
Initialize _containerOffset to 0 explicitly

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ class SortableFlatList extends Component {
   _measurements = []
   _scrollOffset = 0
   _containerSize
-  _containerOffset
+  _containerOffset = 0
   _move = 0
   _hasMoved = false
   _refs = []

--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 import React, { Component, PureComponent } from 'react'
 import {
   LayoutAnimation,
-  YellowBox,
   Animated,
   FlatList,
   View,
@@ -13,7 +12,6 @@ import {
 } from 'react-native'
 
 // Measure function triggers false positives
-YellowBox.ignoreWarnings(['Warning: isMounted(...) is deprecated'])
 UIManager.setLayoutAnimationEnabledExperimental && UIManager.setLayoutAnimationEnabledExperimental(true);
 
 const initialState = {
@@ -341,9 +339,6 @@ class SortableFlatList extends Component {
     const { horizontal, keyExtractor } = this.props
     return (
       <View
-        onLayout={e => {
-          console.log('layout', e.nativeEvent)
-        }}
         ref={this.measureContainer}
         {...this._panResponder.panHandlers}
         style={styles.wrapper} // Setting { opacity: 1 } fixes Android measurement bug: https://github.com/facebook/react-native/issues/18034#issuecomment-368417691


### PR DESCRIPTION
Currently the code from master does not initialize _containerOffset explicitly.
That causes two issues,
1. On iOS, when you drag the item in the list, item disappeared, but dragging to reorder can work.
2. On Android, when you drag the item in the list, error reported as
```
Error while updating property 'transform' of a view managed by: RCTView
```
It's because _containerOffset is undefined and 
```
this._offset.setValue((this._additionalOffset + this._containerOffset - this._androidStatusBarOffset) * -1)
```
could cause this._offset having attribute ```value: NaN```.

Setting _containterOffset to 0 can fix them. Simple and easy.