### PR TITLE
Add onMoveCancel functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Name | Type | Description
 `scrollPercent` | Number | Sets where scrolling begins. A value of `5` will scroll up if the finger is in the top 5% of the FlatList container and scroll down in the bottom 5%. 
 `onMoveEnd` | Function | `({ data, to, from, row }) => void` Returns updated ordering of `data` 
 `onMoveBegin` | Function | `(index) => void` Called when row becomes active.
+`onMoveCancel` | Function | `(index) => void` Called when a row is 'dropped' without being moved at all.
 
 ## Example
 

--- a/index.js
+++ b/index.js
@@ -288,7 +288,10 @@ class SortableFlatList extends Component {
   }
 
   moveEnd = () => {
-    if (!this._hasMoved) this.setState(initialState)
+    if (!this._hasMoved) {
+      this.setState(initialState)
+      if(this.props.onMoveCancel) this.props.onMoveCancel();
+    }
   }
 
   setRef = index => (ref) => {


### PR DESCRIPTION
If the user presses, never moves the selected element and then releases, there is no way
to handle this (control animations and state changes) this allows a prop to be added which
allows it to be handled.