### PR TITLE
Apply contentContainerStyle to the content container

### DIFF
--- a/index.js
+++ b/index.js
@@ -362,7 +362,7 @@ class SortableFlatList extends Component {
   }
 
   render() {
-    const { horizontal, keyExtractor } = this.props
+    const { horizontal, keyExtractor, contentContainerStyle } = this.props
 
     return (
       <View
@@ -371,7 +371,7 @@ class SortableFlatList extends Component {
         }}
         ref={this.measureContainer}
         {...this._panResponder.panHandlers}
-        style={styles.wrapper} // Setting { opacity: 1 } fixes Android measurement bug: https://github.com/facebook/react-native/issues/18034#issuecomment-368417691
+        style={[styles.wrapper, contentContainerStyle]} // Setting { opacity: 1 } fixes Android measurement bug: https://github.com/facebook/react-native/issues/18034#issuecomment-368417691
       >
         <FlatList
           {...this.props}


### PR DESCRIPTION
contentContainerStyle was unused, but it sounds like it's for styling the wrapper View around the FlatList. This commit does just that.