### PR TITLE
Fix Flatlist container

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -804,6 +804,7 @@ class DraggableFlatList<T> extends React.Component<Props<T>, State> {
             <Animated.View
               ref={this.containerRef}
               onLayout={this.onContainerLayout}
+              style={styles.flex}
             >
               <AnimatedFlatList
                 {...this.props}


### PR DESCRIPTION
Component wasn't flexing due to inner container not being flexed.

Thanks for your work! Still a little big buggy on IOS on our side, android is great hehe 