### PR TITLE
Fix list cut

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -802,6 +802,7 @@ class DraggableFlatList<T> extends React.Component<Props<T>, State> {
             onHandlerStateChange={this.onPanStateChange}
           >
             <Animated.View
+              style={styles.flex}
               ref={this.containerRef}
               onLayout={this.onContainerLayout}
             >


### PR DESCRIPTION
When we have a small amount of item, like 3-4 the list don't take all the available space and is cut at the bottom on scroll.