### PR TITLE
V2: Extract interface ListRenderItemInfo from Props

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -69,6 +69,13 @@ const debugGestureState = (state, context) => {
   console.log(`## ${context} debug gesture state: ${state} - ${stateStr}`)
 }
 
+export interface ListRenderItemInfo<T> {
+  item: T,
+  index: number,
+  drag: (index: number) => void,
+  isActive: boolean,
+}
+
 interface Props<T> extends VirtualizedListProps<T> {
   autoscrollSpeed: number,
   autoscrollThreshold: number,
@@ -82,12 +89,7 @@ interface Props<T> extends VirtualizedListProps<T> {
     from: number,
     to: number,
   }) => void
-  renderItem: (params: {
-    item: T,
-    index: number,
-    drag: (index: number) => void,
-    isActive: boolean,
-  }) => React.ComponentType
+  renderItem: (params: ListRenderItemInfo<T>) => React.ComponentType
   animationConfig: Partial<Animated.SpringConfig>,
 }
 


### PR DESCRIPTION
I have created an interface for the  `params` parameter of the `renderItem` prop. A separate interface makes it easier for devs to extract renderItem into a separate function, as they can use the interface for the parameter type.

I'v called it `ListRenderItemInfo` so it matches with its counterpart from `FlatList`.