### PR TITLE
Use FlatListProps instead of VirtualizedListProps

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import {
   Platform,
   StyleSheet,
-  VirtualizedListProps,
+  FlatListProps,
   findNodeHandle,
   ViewStyle,
   FlatList as RNFlatList,
@@ -94,7 +94,7 @@ export type RenderItemParams<T> = {
 
 type Modify<T, R> = Omit<T, keyof R> & R;
 type Props<T> = Modify<
-  VirtualizedListProps<T>,
+  FlatListProps<T>,
   {
     autoscrollSpeed?: number;
     autoscrollThreshold?: number;


### PR DESCRIPTION
When passing `ItemSeparatorComponent` to the draggable FlatList I get an error stating the prop does not exist. It seems `VirtualizedListProps` doesn't have the `ItemSeparatorComponent` prop so I changed it to use `FlatListProps` instead. 

I tested the changes on locally and it cleared up the error. Let me know what you think 👍 