### PR TITLE
Fixed autoscroll being stuck when already scrolled to top/bottom

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "react": "^16.12.0",
     "react-native": "^0.61.5",
     "react-native-gesture-handler": "^1.5.3",
-    "react-native-reanimated": "^1.7.0",
+    "react-native-reanimated": "^1.9.0",
     "typescript": "^3.7.3"
   }
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -226,6 +226,7 @@ class DraggableFlatList<T> extends React.Component<Props<T>, State> {
 
   keyToIndex = new Map<string, number>();
 
+  /** Whether we've sent an incomplete call to the FlatList to do a scroll */
   isAutoscrolling = {
     native: new Value<number>(0),
     js: false
@@ -611,23 +612,49 @@ class DraggableFlatList<T> extends React.Component<Props<T>, State> {
     return targetOffset;
   };
 
-  autoscroll = async ([
-    distFromTop,
-    distFromBottom,
-    scrollOffset,
-    isScrolledUp,
-    isScrolledDown
-  ]: readonly number[]) => {
-    const targetOffset = this.getScrollTargetOffset(
-      distFromTop,
-      distFromBottom,
-      scrollOffset,
-      !!isScrolledUp,
-      !!isScrolledDown
-    );
-    if (targetOffset >= 0 && this.isPressedIn.js) {
-      const nextScrollParams = await this.scrollToAsync(targetOffset);
-      this.autoscroll(nextScrollParams);
+  /** Ensure that only 1 call to autoscroll is active at a time */
+  autoscrollLooping = false;
+  autoscroll = async (params: readonly number[]) => {
+    if (this.autoscrollLooping) {
+      return;
+    }
+    this.autoscrollLooping = true;
+    try {
+      let shouldScroll = true;
+      let curParams = params;
+      while (shouldScroll) {
+        const [
+          distFromTop,
+          distFromBottom,
+          scrollOffset,
+          isScrolledUp,
+          isScrolledDown
+        ] = curParams;
+        const targetOffset = this.getScrollTargetOffset(
+          distFromTop,
+          distFromBottom,
+          scrollOffset,
+          !!isScrolledUp,
+          !!isScrolledDown
+        );
+        const scrollingUpAtTop = !!(
+          isScrolledUp && targetOffset <= scrollOffset
+        );
+        const scrollingDownAtBottom = !!(
+          isScrolledDown && targetOffset >= scrollOffset
+        );
+        shouldScroll =
+          targetOffset >= 0 &&
+          this.isPressedIn.js &&
+          !scrollingUpAtTop &&
+          !scrollingDownAtBottom;
+
+        if (shouldScroll) {
+          curParams = await this.scrollToAsync(targetOffset);
+        }
+      }
+    } finally {
+      this.autoscrollLooping = false;
     }
   };
 
@@ -669,17 +696,26 @@ class DraggableFlatList<T> extends React.Component<Props<T>, State> {
             and(
               this.isAutoscrolling.native,
               or(
+                // We've scrolled to where we want to be
                 lessOrEq(
                   abs(sub(this.targetScrollOffset, this.scrollOffset)),
                   scrollPositionTolerance
                 ),
-                this.isScrolledUp,
-                this.isScrolledDown
+                // We're at the start, but still want to scroll farther up
+                and(
+                  this.isScrolledUp,
+                  lessOrEq(this.targetScrollOffset, this.scrollOffset)
+                ),
+                // We're at the end, but still want to scroll further down
+                and(
+                  this.isScrolledDown,
+                  greaterOrEq(this.targetScrollOffset, this.scrollOffset)
+                )
               )
             ),
             [
+              // Finish scrolling
               set(this.isAutoscrolling.native, 0),
-              this.checkAutoscroll,
               call(this.autoscrollParams, this.onAutoscrollComplete)
             ]
           )

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -815,7 +815,10 @@ class DraggableFlatList<T> extends React.Component<Props<T>, State> {
                 [`translate${horizontal ? "X" : "Y"}`]: this
                   .hoverComponentTranslate
               }
-            ]
+              // We need the cast because the transform array usually accepts
+              // only specific keys, and we dynamically generate the key
+              // above
+            ] as Animated.AnimatedTransform
           }
         ]}
       >

--- a/src/procs.tsx
+++ b/src/procs.tsx
@@ -1,5 +1,4 @@
 import Animated from "react-native-reanimated";
-import { State as GestureState } from "react-native-gesture-handler";
 
 let {
   or,
@@ -68,9 +67,16 @@ export const hardReset = proc(
     block([set(position, 0), set(finished, 0), set(time, 0), set(toValue, 0)])
 );
 
-export const setupCell = proc(
+/**
+ * The in react-native-reanimated.d.ts definition of `proc` only has generics
+ * for up to 10 arguments. We cast it to accept any params to avoid errors when
+ * type-checking.
+ */
+type RetypedProc = (cb: (...params: any) => Animated.Node<number>) => typeof cb;
+
+export const setupCell = (proc as RetypedProc)(
   (
-    currentIndex: Animated.Node<number>,
+    currentIndex: Animated.Value<number>,
     initialized: Animated.Value<number>,
     size: Animated.Node<number>,
     offset: Animated.Node<number>,
@@ -207,7 +213,7 @@ export const setupCell = proc(
     ])
 );
 
-const betterSpring = proc(
+const betterSpring = (proc as RetypedProc)(
   (
     finished: Animated.Value<number>,
     velocity: Animated.Value<number>,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3740,10 +3740,12 @@ react-native-gesture-handler@^1.5.3:
     invariant "^2.2.4"
     prop-types "^15.7.2"
 
-react-native-reanimated@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-1.7.0.tgz#896db2576552ac59d288a1f6c7f00afc171f240c"
-  integrity sha512-FQWSqP605eQVJumuK2HpR+7heF0ZI+qfy4jNguv3Xv8nPFHeIgZaRTXHCEQL2AcuSIj50zy8jGJf5l134QMQWQ==
+react-native-reanimated@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-1.9.0.tgz#38676c99dd585504fdc7331efb45e5f48ec7339a"
+  integrity sha512-Aj+spgIHRiVv7ezGADxnSH1EoKrQRD2+XaSiGY0MiB/pvRNNrZPSJ+3NVpvLwWf9lZMOP7dwqqyJIzoZgBDt8w==
+  dependencies:
+    fbjs "^1.0.0"
 
 react-native@^0.61.5:
   version "0.61.5"


### PR DESCRIPTION
## Motivation

1. When trying to scroll down by dragging an item while the list is scrolled at the top, the scroll never starts
2. When trying to build the app, we get the error:

```
node_modules/react-native-reanimated/react-native-reanimated.d.ts:477:7 - error TS1254: A 'const' initializer in an ambient context must be a string or numeric literal or literal enum reference.

477   } = Animated;
          ~~~~~~~~


Found 1 error.
```

## Debugging for scrolling issue

This was happening because:

1. `autoscroll` is called, and it calls `scrollToAsync`, which creates a promise
2. `onScroll` is called even before the scroll happens, and immediately calls `this.onAutoscrollComplete` with the current scroll position (at the top of the document) because `this.isScrolledUp` is true. This then resolves the `scrollToAsync` promise with the current document state (not scrolled, still at the top)
3. `autoscroll` calls itself recursively, but with `nextScrollParams` being the same as the first set of `nextScrollParams`, which is at the top of the document. It then tries to scroll to the same position

This makes the document be constantly trying to scroll to the same position, but not starting

## Fix for scrolling issue

1. Ensure `autoscroll` can't be called simultaneously so that it never tries to repeatedly scroll to the same place
   - It's now only called in the pan handler, and a variable ensures that only one instance is running
   - I made it a loop instead of recursive to make this easier
2. Instead of only checking `this.isScrolledUp` and `this.isScrolledDown` and marking the scroll as done immediately, we should check only `this.isScrolledUp` only while scrolling up and `this.isScrolledDown` only while scrolling down

## Fix for typings

- Upgraded react-native-reanimated types to fix the issue with latest Typescript
- Fixed our typings for the new reanimated typings

## Testing

| Before | After |
| --- | --- |
| ![Before](https://user-images.githubusercontent.com/2937410/87472005-1b4d2280-c5d4-11ea-8a58-d9c82713398b.gif) | ![After](https://user-images.githubusercontent.com/2937410/87472023-2011d680-c5d4-11ea-81c4-ad811fb93bfb.gif) |