### PR TITLE
Add stretch to flex style

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1074,7 +1074,8 @@ class RowItem<T> extends React.PureComponent<RowItemProps<T>> {
 
 const styles = StyleSheet.create({
   flex: {
-    flex: 1
+    flex: 1,
+    alignSelf: "stretch"
   },
   hoverComponentVertical: {
     position: "absolute",


### PR DESCRIPTION
This component wasn't expanding to its parent as expected. Adding `alignSelf: stretch` to `styles.flex` resolves the issue.