### PR TITLE
Fix onPressIn swipe

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -826,19 +826,17 @@ class DraggableFlatList<T> extends React.Component<
   onPanGestureEvent = event([
     {
       nativeEvent: ({ x, y }: PanGestureHandlerGestureEvent["nativeEvent"]) =>
-        block([
-          cond(
-            and(
-              this.isHovering,
-              eq(this.panGestureState, GestureState.ACTIVE),
-              not(this.disabled)
-            ),
-            [
-              cond(not(this.hasMoved), set(this.hasMoved, 1)),
-              [set(this.touchAbsolute, this.props.horizontal ? x : y)]
-            ]
-          )
-        ])
+        cond(
+          and(
+            this.isHovering,
+            eq(this.panGestureState, GestureState.ACTIVE),
+            not(this.disabled)
+          ),
+          [
+            cond(not(this.hasMoved), set(this.hasMoved, 1)),
+            [set(this.touchAbsolute, this.props.horizontal ? x : y)]
+          ]
+        )
     }
   ]);
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -157,11 +157,10 @@ class DraggableFlatList<T> extends React.Component<
 
   containerSize = new Value<number>(0);
 
-  activationDistance = new Value<number>(0);
-  touchInit = new Value<number>(0);
-  touchAbsolute = new Value<number>(0);
+  touchInit = new Value<number>(0); // Position of initial touch
+  activationDistance = new Value<number>(0); // Distance finger travels from initial touch to when dragging begins
+  touchAbsolute = new Value<number>(0); // Finger position on screen, relative to container
   panGestureState = new Value(GestureState.UNDETERMINED);
-  activeCellOffset = new Value<number>(0);
 
   isPressedIn = {
     native: new Value<number>(0),
@@ -171,11 +170,12 @@ class DraggableFlatList<T> extends React.Component<
   hasMoved = new Value(0);
   disabled = new Value(0);
 
-  activeIndex = new Value<number>(-1);
+  activeIndex = new Value<number>(-1); // Index of hovering cell
+  spacerIndex = new Value<number>(-1); // Index of hovered-over cell
   isHovering = greaterThan(this.activeIndex, -1);
 
-  spacerIndex = new Value<number>(-1);
-  activeCellSize = new Value<number>(0);
+  activeCellSize = new Value<number>(0); // Height or width of acctive cell
+  activeCellOffset = new Value<number>(0); // Distance between active cell and edge of container
 
   scrollOffset = new Value<number>(0);
   scrollViewSize = new Value<number>(0);
@@ -185,7 +185,7 @@ class DraggableFlatList<T> extends React.Component<
     this.scrollViewSize
   );
 
-  touchCellOffset = sub(this.touchInit, this.activeCellOffset);
+  touchCellOffset = sub(this.touchInit, this.activeCellOffset); // Distance between touch point and edge of cell
   hoverAnimUnconstrained = sub(
     sub(this.touchAbsolute, this.activationDistance),
     this.touchCellOffset

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from "react";
 import {
   Platform,
   StyleSheet,
@@ -7,27 +7,18 @@ import {
   ViewStyle,
   FlatList as RNFlatList,
   NativeScrollEvent,
-  StyleProp,
-} from 'react-native';
+  StyleProp
+} from "react-native";
 import {
   PanGestureHandler,
   State as GestureState,
   FlatList,
   PanGestureHandlerProperties,
   PanGestureHandlerStateChangeEvent,
-  PanGestureHandlerGestureEvent,
-} from 'react-native-gesture-handler';
-import Animated from 'react-native-reanimated';
-import { springFill, setupCell } from './procs';
-
-const RevState = {
-  0: 'undetermined',
-  1: 'faied',
-  2: 'began',
-  3: 'canceled',
-  4: 'active',
-  5: 'end',
-};
+  PanGestureHandlerGestureEvent
+} from "react-native-gesture-handler";
+import Animated from "react-native-reanimated";
+import { springFill, setupCell } from "./procs";
 
 const AnimatedFlatList = Animated.createAnimatedComponent(FlatList);
 
@@ -59,7 +50,7 @@ const {
   defined,
   min,
   max,
-  debug,
+  debug
 } = Animated;
 
 // Fire onScrollComplete when within this many
@@ -71,7 +62,7 @@ const defaultAnimationConfig = {
   stiffness: 100,
   overshootClamping: false,
   restSpeedThreshold: 0.2,
-  restDisplacementThreshold: 0.2,
+  restDisplacementThreshold: 0.2
 };
 
 const defaultProps = {
@@ -79,9 +70,9 @@ const defaultProps = {
   autoscrollSpeed: 100,
   animationConfig: defaultAnimationConfig as Animated.SpringConfig,
   scrollEnabled: true,
-  dragHitSlop: 0 as PanGestureHandlerProperties['hitSlop'],
+  dragHitSlop: 0 as PanGestureHandlerProperties["hitSlop"],
   activationDistance: 0,
-  dragItemOverflow: false,
+  dragItemOverflow: false
 };
 
 type DefaultProps = Readonly<typeof defaultProps>;
@@ -146,7 +137,7 @@ type CellData = {
 // Run callback on next paint:
 // https://stackoverflow.com/questions/26556436/react-after-render-code
 function onNextFrame(callback: () => void) {
-  setTimeout(function () {
+  setTimeout(function() {
     requestAnimationFrame(callback);
   });
 }
@@ -154,10 +145,10 @@ function onNextFrame(callback: () => void) {
 class DraggableFlatList<T> extends React.Component<
   DraggableFlatListProps<T>,
   State
-  > {
+> {
   state: State = {
     activeKey: null,
-    hoverComponent: null,
+    hoverComponent: null
   };
 
   containerRef = React.createRef<Animated.View>();
@@ -167,14 +158,14 @@ class DraggableFlatList<T> extends React.Component<
   containerSize = new Value<number>(0);
 
   activationDistance = new Value<number>(0);
-  touchInit = new Value<number>(0)
+  touchInit = new Value<number>(0);
   touchAbsolute = new Value<number>(0);
   panGestureState = new Value(GestureState.UNDETERMINED);
-  activeCellOffset = new Value<number>(0)
+  activeCellOffset = new Value<number>(0);
 
   isPressedIn = {
     native: new Value<number>(0),
-    js: false,
+    js: false
   };
 
   hasMoved = new Value(0);
@@ -194,8 +185,11 @@ class DraggableFlatList<T> extends React.Component<
     this.scrollViewSize
   );
 
-  touchCellOffset = sub(this.touchInit, this.activeCellOffset)
-  hoverAnimUnconstrained = sub(sub(this.touchAbsolute, this.activationDistance), this.touchCellOffset)
+  touchCellOffset = sub(this.touchInit, this.activeCellOffset);
+  hoverAnimUnconstrained = sub(
+    sub(this.touchAbsolute, this.activationDistance),
+    this.touchCellOffset
+  );
   hoverAnimConstrained = min(
     sub(this.containerSize, this.activeCellSize),
     max(0, this.hoverAnimUnconstrained)
@@ -216,13 +210,13 @@ class DraggableFlatList<T> extends React.Component<
     finished: new Value(0),
     velocity: new Value(0),
     position: new Value(0),
-    time: new Value(0),
+    time: new Value(0)
   };
 
   hoverAnimConfig = {
     ...defaultAnimationConfig,
     ...this.props.animationConfig,
-    toValue: this.hoverTo,
+    toValue: this.hoverTo
   };
 
   distToTopEdge = max(0, this.hoverAnim);
@@ -260,14 +254,14 @@ class DraggableFlatList<T> extends React.Component<
 
   isAutoScrollInProgress = {
     native: new Value<number>(0),
-    js: false,
+    js: false
   };
 
   queue: (() => void | Promise<void>)[] = [];
 
   static getDerivedStateFromProps(props: DraggableFlatListProps<any>) {
     return {
-      extraData: props.extraData,
+      extraData: props.extraData
     };
   }
 
@@ -290,7 +284,7 @@ class DraggableFlatList<T> extends React.Component<
     const aKeys = a.map((d, i) => this.keyExtractor(d, i));
     const bKeys = b.map((d, i) => this.keyExtractor(d, i));
 
-    const sameKeys = aKeys.every((k) => bKeys.includes(k));
+    const sameKeys = aKeys.every(k => bKeys.includes(k));
     return !sameKeys;
   };
 
@@ -334,7 +328,7 @@ class DraggableFlatList<T> extends React.Component<
   };
 
   flushQueue = async () => {
-    this.queue.forEach((fn) => fn());
+    this.queue.forEach(fn => fn());
     this.queue = [];
   };
 
@@ -345,7 +339,7 @@ class DraggableFlatList<T> extends React.Component<
     if (this.state.hoverComponent !== null || this.state.activeKey !== null) {
       this.setState({
         hoverComponent: null,
-        activeKey: null,
+        activeKey: null
       });
     }
   };
@@ -361,7 +355,7 @@ class DraggableFlatList<T> extends React.Component<
       this.setState(
         {
           activeKey,
-          hoverComponent,
+          hoverComponent
         },
         () => {
           const index = this.keyToIndex.get(activeKey);
@@ -419,14 +413,14 @@ class DraggableFlatList<T> extends React.Component<
 
     const config = {
       ...this.hoverAnimConfig,
-      toValue: new Value(0),
+      toValue: new Value(0)
     };
 
     const state = {
       position: new Value(0),
       velocity: new Value(0),
       time: new Value(0),
-      finished: new Value(0),
+      finished: new Value(0)
     };
 
     this.cellAnim.set(key, { clock, state, config });
@@ -482,7 +476,7 @@ class DraggableFlatList<T> extends React.Component<
       : [{ translateY: anim }];
 
     const style = {
-      transform,
+      transform
     };
 
     const cellData = {
@@ -497,8 +491,8 @@ class DraggableFlatList<T> extends React.Component<
       onUnmount: () => initialized.setValue(0),
       measurements: {
         size: 0,
-        offset: 0,
-      },
+        offset: 0
+      }
     };
     this.cellData.set(key, cellData);
   };
@@ -557,7 +551,7 @@ class DraggableFlatList<T> extends React.Component<
       };
 
       const onFail = () => {
-        if (this.props.debug) console.log('## measureLayout fail!', key);
+        if (this.props.debug) console.log("## measureLayout fail!", key);
       };
 
       const ref = this.cellRefs.get(key);
@@ -570,10 +564,10 @@ class DraggableFlatList<T> extends React.Component<
         if (nodeHandle) viewNode.measureLayout(nodeHandle, onSuccess, onFail);
       } else {
         let reason = !ref
-          ? 'no ref'
+          ? "no ref"
           : !flatListNode
-            ? 'no flatlist node'
-            : 'invalid ref';
+          ? "no flatlist node"
+          : "invalid ref";
         if (this.props.debug)
           console.log(`## can't measure ${key} reason: ${reason}`);
         this.queue.push(() => this.measureCell(key));
@@ -585,7 +579,7 @@ class DraggableFlatList<T> extends React.Component<
   keyExtractor = (item: T, index: number) => {
     if (this.props.keyExtractor) return this.props.keyExtractor(item, index);
     else
-      throw new Error('You must provide a keyExtractor to DraggableFlatList');
+      throw new Error("You must provide a keyExtractor to DraggableFlatList");
   };
 
   onContainerLayout = () => {
@@ -642,7 +636,7 @@ class DraggableFlatList<T> extends React.Component<
     const speedPct = 1 - distFromEdge / autoscrollThreshold!;
     // Android scroll speed seems much faster than ios
     const speed =
-      Platform.OS === 'ios' ? autoscrollSpeed! : autoscrollSpeed! / 10;
+      Platform.OS === "ios" ? autoscrollSpeed! : autoscrollSpeed! / 10;
     const offset = speedPct * speed;
     const targetOffset = scrollUp
       ? Math.max(0, scrollOffset - offset)
@@ -666,7 +660,7 @@ class DraggableFlatList<T> extends React.Component<
           distFromBottom,
           scrollOffset,
           isScrolledUp,
-          isScrolledDown,
+          isScrolledDown
         ] = curParams;
         const targetOffset = this.getScrollTargetOffset(
           distFromTop,
@@ -708,7 +702,7 @@ class DraggableFlatList<T> extends React.Component<
     this.distToBottomEdge,
     this.scrollOffset,
     this.isScrolledUp,
-    this.isScrolledDown,
+    this.isScrolledDown
   ];
 
   checkAutoscroll = cond(
@@ -754,11 +748,11 @@ class DraggableFlatList<T> extends React.Component<
             [
               // Finish scrolling
               set(this.isAutoScrollInProgress.native, 0),
-              call(this.autoscrollParams, this.onAutoscrollComplete),
+              call(this.autoscrollParams, this.onAutoscrollComplete)
             ]
-          ),
-        ]),
-    },
+          )
+        ])
+    }
   ]);
 
   onGestureRelease = [
@@ -767,22 +761,20 @@ class DraggableFlatList<T> extends React.Component<
       [
         set(this.disabled, 1),
         cond(defined(this.hoverClock), [
-          cond(clockRunning(this.hoverClock), [
-            stopClock(this.hoverClock)
-          ]),
+          cond(clockRunning(this.hoverClock), [stopClock(this.hoverClock)]),
           set(this.hoverAnimState.position, this.hoverAnim),
-          startClock(this.hoverClock),
+          startClock(this.hoverClock)
         ]),
         [
           call([this.activeIndex], this.onRelease),
           cond(
             not(this.hasMoved),
             call([this.activeIndex], this.resetHoverState)
-          ),
-        ],
+          )
+        ]
       ],
       call([this.activeIndex], this.resetHoverState)
-    ),
+    )
   ];
 
   onPanStateChange = event([
@@ -790,30 +782,33 @@ class DraggableFlatList<T> extends React.Component<
       nativeEvent: ({
         state,
         x,
-        y,
+        y
       }: PanGestureHandlerStateChangeEvent["nativeEvent"]) =>
         cond(and(neq(state, this.panGestureState), not(this.disabled)), [
-          cond(or(
-            eq(state, GestureState.BEGAN),
-            // GestureState.BEGAN may be skipped on fast swipes
-            and(eq(state, GestureState.ACTIVE), neq(this.panGestureState, GestureState.BEGAN)),
-          ), [
-            set(this.touchAbsolute, this.props.horizontal ? x : y),
-            set(this.touchInit, this.touchAbsolute),
-          ]),
           cond(
-            eq(state, GestureState.ACTIVE),
+            or(
+              eq(state, GestureState.BEGAN),
+              // GestureState.BEGAN may be skipped on fast swipes
+              and(
+                eq(state, GestureState.ACTIVE),
+                neq(this.panGestureState, GestureState.BEGAN)
+              )
+            ),
             [
-              set(
-                this.activationDistance,
-                sub(this.props.horizontal ? x : y, this.touchInit)
-              ),
               set(this.touchAbsolute, this.props.horizontal ? x : y),
+              set(this.touchInit, this.touchAbsolute)
             ]
           ),
+          cond(eq(state, GestureState.ACTIVE), [
+            set(
+              this.activationDistance,
+              sub(this.props.horizontal ? x : y, this.touchInit)
+            ),
+            set(this.touchAbsolute, this.props.horizontal ? x : y)
+          ]),
           cond(
             neq(this.panGestureState, state),
-            set(this.panGestureState, state),
+            set(this.panGestureState, state)
           ),
           cond(
             or(
@@ -822,9 +817,9 @@ class DraggableFlatList<T> extends React.Component<
               eq(state, GestureState.FAILED)
             ),
             this.onGestureRelease
-          ),
-        ]),
-    },
+          )
+        ])
+    }
   ]);
 
   onPanGestureEvent = event([
@@ -839,16 +834,11 @@ class DraggableFlatList<T> extends React.Component<
             ),
             [
               cond(not(this.hasMoved), set(this.hasMoved, 1)),
-              [
-                set(
-                  this.touchAbsolute,
-                  this.props.horizontal ? x : y
-                ),
-              ]
+              [set(this.touchAbsolute, this.props.horizontal ? x : y)]
             ]
-          ),
-        ]),
-    },
+          )
+        ])
+    }
   ]);
 
   hoverComponentTranslate = cond(
@@ -876,14 +866,16 @@ class DraggableFlatList<T> extends React.Component<
             opacity: this.hoverComponentOpacity,
             transform: [
               {
-                [`translate${horizontal ? 'X' : 'Y'}`]: this.hoverComponentTranslate
-              },
+                [`translate${horizontal ? "X" : "Y"}`]: this
+                  .hoverComponentTranslate
+              }
               // We need the cast because the transform array usually accepts
               // only specific keys, and we dynamically generate the key
               // above
-            ] as Animated.AnimatedTransform,
-          },
-        ]}>
+            ] as Animated.AnimatedTransform
+          }
+        ]}
+      >
         {hoverComponent}
       </Animated.View>
     );
@@ -896,8 +888,8 @@ class DraggableFlatList<T> extends React.Component<
     if (!this.cellData.get(key)) this.setCellData(key, index);
     const { onUnmount } = this.cellData.get(key) || {
       onUnmount: () => {
-        if (this.props.debug) console.log('## error, no cellData');
-      },
+        if (this.props.debug) console.log("## error, no cellData");
+      }
     };
     return (
       <RowItem
@@ -921,7 +913,7 @@ class DraggableFlatList<T> extends React.Component<
             call([this.spacerIndex], ([spacerIndex]) =>
               this.props.onPlaceholderIndexChange!(spacerIndex)
             )
-          ),
+          )
         ])
       }
     </Animated.Code>
@@ -934,14 +926,14 @@ class DraggableFlatList<T> extends React.Component<
     const activeIndex = this.keyToIndex.get(activeKey);
     if (activeIndex === undefined) return null;
     const activeItem = this.props.data[activeIndex];
-    const translateKey = horizontal ? 'translateX' : 'translateY';
-    const sizeKey = horizontal ? 'width' : 'height';
+    const translateKey = horizontal ? "translateX" : "translateY";
+    const sizeKey = horizontal ? "width" : "height";
     const style = {
       ...StyleSheet.absoluteFillObject,
       [sizeKey]: this.activeCellSize,
       transform: [
-        { [translateKey]: this.placeholderPos },
-      ] as Animated.AnimatedTransform,
+        { [translateKey]: this.placeholderPos }
+      ] as Animated.AnimatedTransform
     };
 
     return (
@@ -969,14 +961,16 @@ class DraggableFlatList<T> extends React.Component<
     return (
       <Animated.View onLayout={onLayout} style={style}>
         <Animated.View
-          pointerEvents={activeKey ? 'none' : 'auto'}
+          pointerEvents={activeKey ? "none" : "auto"}
           style={{
-            flexDirection: horizontal ? 'row' : 'column',
-          }}>
+            flexDirection: horizontal ? "row" : "column"
+          }}
+        >
           <Animated.View
             ref={ref}
             onLayout={onCellLayout}
-            style={isActiveCell ? { opacity: 0 } : undefined}>
+            style={isActiveCell ? { opacity: 0 } : undefined}
+          >
             {children}
           </Animated.View>
         </Animated.View>
@@ -989,10 +983,7 @@ class DraggableFlatList<T> extends React.Component<
       <Animated.Code dependencies={[]}>
         {() =>
           block([
-            onChange(
-              this.spacerIndex,
-              debug('spacerIndex: ', this.spacerIndex)
-            ),
+            onChange(this.spacerIndex, debug("spacerIndex: ", this.spacerIndex))
           ])
         }
       </Animated.Code>
@@ -1012,7 +1003,7 @@ class DraggableFlatList<T> extends React.Component<
       onScrollOffsetChange,
       renderPlaceholder,
       onPlaceholderIndexChange,
-      containerStyle,
+      containerStyle
     } = this.props;
 
     const { hoverComponent } = this.state;
@@ -1029,12 +1020,14 @@ class DraggableFlatList<T> extends React.Component<
         hitSlop={dragHitSlop}
         onGestureEvent={this.onPanGestureEvent}
         onHandlerStateChange={this.onPanStateChange}
-        {...dynamicProps}>
+        {...dynamicProps}
+      >
         <Animated.View
           style={[styles.flex, containerStyle]}
           ref={this.containerRef}
           onLayout={this.onContainerLayout}
-          onTouchEnd={this.onContainerTouchEnd}>
+          onTouchEnd={this.onContainerTouchEnd}
+        >
           {!!onPlaceholderIndexChange && this.renderOnPlaceholderIndexChange()}
           {!!renderPlaceholder && this.renderPlaceholder()}
           <AnimatedFlatList
@@ -1070,9 +1063,9 @@ class DraggableFlatList<T> extends React.Component<
                     this.resetHoverSpring,
                     stopClock(this.hoverClock),
                     call(this.moveEndParams, this.onDragEnd),
-                    set(this.hasMoved, 0),
-                  ]),
-                ]),
+                    set(this.hasMoved, 0)
+                  ])
+                ])
               ])
             }
           </Animated.Code>
@@ -1117,8 +1110,8 @@ class RowItem<T> extends React.PureComponent<RowItemProps<T>> {
       index: keyToIndex.get(itemKey),
       drag: () => {
         if (debug)
-          console.log('## attempt to call drag() on hovering component');
-      },
+          console.log("## attempt to call drag() on hovering component");
+      }
     });
     drag(hoverComponent, itemKey);
   };
@@ -1133,23 +1126,23 @@ class RowItem<T> extends React.PureComponent<RowItemProps<T>> {
       isActive: false,
       item,
       index: keyToIndex.get(itemKey),
-      drag: this.drag,
+      drag: this.drag
     });
   }
 }
 
 const styles = StyleSheet.create({
   flex: {
-    flex: 1,
+    flex: 1
   },
   hoverComponentVertical: {
-    position: 'absolute',
+    position: "absolute",
     left: 0,
-    right: 0,
+    right: 0
   },
   hoverComponentHorizontal: {
-    position: 'absolute',
+    position: "absolute",
     bottom: 0,
-    top: 0,
-  },
+    top: 0
+  }
 });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -335,6 +335,7 @@ class DraggableFlatList<T> extends React.Component<
   resetHoverState = () => {
     this.activeIndex.setValue(-1);
     this.spacerIndex.setValue(-1);
+    this.touchAbsolute.setValue(0);
     this.disabled.setValue(0);
     if (this.state.hoverComponent !== null || this.state.activeKey !== null) {
       this.setState({
@@ -787,7 +788,7 @@ class DraggableFlatList<T> extends React.Component<
         cond(and(neq(state, this.panGestureState), not(this.disabled)), [
           cond(
             or(
-              eq(state, GestureState.BEGAN),
+              eq(state, GestureState.BEGAN), // Called on press in on Android, NOT on ios!
               // GestureState.BEGAN may be skipped on fast swipes
               and(
                 eq(state, GestureState.ACTIVE),

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1082,7 +1082,7 @@ class DraggableFlatList<T> extends React.Component<
               }
             </Animated.Code>
           )}
-          {debug && this.renderDebug()}
+          {!!this.props.debug && this.renderDebug()}
         </Animated.View>
       </PanGestureHandler>
     );


### PR DESCRIPTION
- Fix case where use if quickly swiping using `onPressIn`
- Separated some animated values that were tracking too much into single-purpose values
- General cleanup

Fixes https://github.com/computerjazz/react-native-draggable-flatlist/issues/214