### PR TITLE
fix: Bad hover offset when used in pager

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,6 +8,7 @@ import {
   FlatList as RNFlatList,
   NativeScrollEvent,
   StyleProp,
+  LayoutChangeEvent,
 } from "react-native";
 import {
   PanGestureHandler,
@@ -588,14 +589,13 @@ class DraggableFlatList<T> extends React.Component<
       throw new Error("You must provide a keyExtractor to DraggableFlatList");
   };
 
-  onContainerLayout = () => {
+  onContainerLayout: (event: LayoutChangeEvent) => void = ({
+    nativeEvent: {
+      layout: { width, height },
+    },
+  }) => {
     const { horizontal } = this.props;
-    const containerRef = this.containerRef.current;
-    if (containerRef) {
-      containerRef.getNode().measure((_x, _y, w, h) => {
-        this.containerSize.setValue(horizontal ? w : h);
-      });
-    }
+    this.containerSize.setValue(horizontal ? width : height);
   };
 
   onListContentSizeChange = (w: number, h: number) => {


### PR DESCRIPTION
When the draggable list is rendered in [react-native-pager-view](https://github.com/callstack/react-native-pager-view) or a `ScrollView` with `removeClippedSubviews` the list will only work on the first page.

`containerRef.getNode().measure` will return undefined for `w` and `h`, due to this when dragging an item it will go out of the list.

Heres a video of the bug:

https://user-images.githubusercontent.com/50402950/119359441-ea388680-bca9-11eb-924f-01dd5331a8a6.mp4

And heres a video after the fix:

https://user-images.githubusercontent.com/50402950/119359786-413e5b80-bcaa-11eb-8b49-7b88fceb0174.mp4


I have tested it on:
- [x] iOS simulator
- [x] Android emulator

PS: I can provide the example if needed