### PR TITLE
fixed layout measurement

### DIFF
--- a/src/components/DraggableFlatList.tsx
+++ b/src/components/DraggableFlatList.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useLayoutEffect, useMemo, useState } from "react";
-import { ListRenderItem, FlatListProps } from "react-native";
+import { ListRenderItem, FlatListProps, LayoutChangeEvent } from "react-native";
 import {
   FlatList,
   PanGestureHandler,
@@ -127,13 +127,9 @@ function DraggableFlatListInner<T>(props: DraggableFlatListProps<T>) {
     ]
   );
 
-  const onContainerLayout = () => {
-    const containerNode = containerRef.current;
-
-    //@ts-ignore
-    containerNode?.measure((_x, _y, w, h) => {
-      containerSize.value = props.horizontal ? w : h;
-    });
+  const onContainerLayout = ({ nativeEvent: { layout } }: LayoutChangeEvent) => {
+    const { width, height } = layout;
+    containerSize.value = props.horizontal ? width : height;
   };
 
   const onListContentSizeChange = (w: number, h: number) => {


### PR DESCRIPTION
According to official react native documentation measurements are not available until after the rendering has been completed in native. https://reactnative.dev/docs/direct-manipulation#measurecallback

`Note that these measurements are not available until after the rendering has been completed in native. If you need the measurements as soon as possible and you don't need pageX and pageY, consider using the onLayout property instead`

https://reactnative.dev/docs/view#onlayout

Fixes #313 