### PR TITLE
Fix CellRendererComponent to not error when no onLayout provided

### DIFF
--- a/src/components/CellRendererComponent.tsx
+++ b/src/components/CellRendererComponent.tsx
@@ -25,7 +25,7 @@ type Props<T> = {
   item: T;
   index: number;
   children: React.ReactNode;
-  onLayout: (e: LayoutChangeEvent) => void;
+  onLayout?: (e: LayoutChangeEvent) => void;
   style?: StyleProp<ViewStyle>;
 };
 
@@ -129,7 +129,7 @@ function CellRendererComponent<T>(props: Props<T>) {
   const onCellLayout = useCallback(
     (e: LayoutChangeEvent) => {
       updateCellMeasurements();
-      onLayout(e);
+      if (onLayout) onLayout(e);
     },
     [updateCellMeasurements, onLayout]
   );


### PR DESCRIPTION
## Motivation

While using the latest version of react-native-draggable-flatlist in the Wanderlog app, we ran into this error:

![image](https://user-images.githubusercontent.com/2937410/152618012-4e96398d-61e1-4ed0-bfdc-517caa9a4128.png)

This points to this bit of compiled code:

```ts
    var onCellLayout = react_1.useCallback(function (e) {
        updateCellMeasurements();
        onLayout(e);
    }, [updateCellMeasurements, onLayout]);
```

Reading the React documentation on FlatList, it doesn't make any mention that `onLayout` will always be provided, and I'm guessing it isn't provided by default with the version of RN (0.64) and react-native-reanimated (2.3.1) that I"m using.

## Fix

Don't call `onLayout` if it's undefined

## Testing

Tested in app and verified the error is now gone