### PR TITLE
Improve DraggableFlatList performance

### DIFF
--- a/src/components/DraggableFlatList.tsx
+++ b/src/components/DraggableFlatList.tsx
@@ -191,7 +191,7 @@ function DraggableFlatListInner<T>(props: DraggableFlatListProps<T>) {
       const key = keyExtractor(item, index);
       if (index !== keyToIndexRef.current.get(key))
         keyToIndexRef.current.set(key, index);
-      const passIndexToRenderItem = props.passIndexToRenderItem !== false
+      const passIndexToRenderItem = props.passIndexToRenderItem ?? true;
 
       return (
         <RowItem

--- a/src/components/DraggableFlatList.tsx
+++ b/src/components/DraggableFlatList.tsx
@@ -48,6 +48,7 @@ import AnimatedValueProvider, {
 } from "../context/animatedValueContext";
 import RefProvider, { useRefs } from "../context/refContext";
 import DraggableFlatListProvider from "../context/draggableFlatListContext";
+import {typedMemo} from "../utils";
 
 type RNGHFlatListProps<T> = Animated.AnimateProps<
   FlatListProps<T> & {
@@ -190,6 +191,7 @@ function DraggableFlatListInner<T>(props: DraggableFlatListProps<T>) {
       const key = keyExtractor(item, index);
       if (index !== keyToIndexRef.current.get(key))
         keyToIndexRef.current.set(key, index);
+      const passIndexToRenderItem = props.passIndexToRenderItem !== false
 
       return (
         <RowItem
@@ -198,6 +200,7 @@ function DraggableFlatListInner<T>(props: DraggableFlatListProps<T>) {
           renderItem={props.renderItem}
           drag={drag}
           extraData={props.extraData}
+          passIndexToRenderItem={passIndexToRenderItem}
         />
       );
     },
@@ -424,6 +427,8 @@ function DraggableFlatListInner<T>(props: DraggableFlatListProps<T>) {
   );
 }
 
+const MemoizedDraggableFlatListInner = typedMemo(DraggableFlatListInner);
+
 function DraggableFlatList<T>(
   props: DraggableFlatListProps<T>,
   ref: React.ForwardedRef<FlatList<T>>
@@ -432,7 +437,7 @@ function DraggableFlatList<T>(
     <PropsProvider {...props}>
       <AnimatedValueProvider>
         <RefProvider flatListRef={ref}>
-          <DraggableFlatListInner {...props} />
+          <MemoizedDraggableFlatListInner {...props} />
         </RefProvider>
       </AnimatedValueProvider>
     </PropsProvider>

--- a/src/components/RowItem.tsx
+++ b/src/components/RowItem.tsx
@@ -42,7 +42,9 @@ function RowItem<T>(props: Props<T>) {
       drag={drag}
       renderItem={renderItem}
       item={item}
-      index={passIndexToRenderItem? keyToIndexRef.current.get(itemKey): undefined}
+      index={
+        passIndexToRenderItem ? keyToIndexRef.current.get(itemKey) : undefined
+      }
       extraData={extraData}
     />
   );

--- a/src/components/RowItem.tsx
+++ b/src/components/RowItem.tsx
@@ -10,6 +10,7 @@ type Props<T> = {
   item: T;
   renderItem: RenderItem<T>;
   itemKey: string;
+  passIndexToRenderItem: boolean;
   debug?: boolean;
 };
 
@@ -34,14 +35,14 @@ function RowItem<T>(props: Props<T>) {
     drag(itemKey);
   }, []);
 
-  const { renderItem, item, itemKey, extraData } = props;
+  const { renderItem, item, itemKey, extraData, passIndexToRenderItem } = props;
   return (
     <MemoizedInner
       isActive={activeKey === itemKey}
       drag={drag}
       renderItem={renderItem}
       item={item}
-      index={keyToIndexRef.current.get(itemKey)}
+      index={passIndexToRenderItem? keyToIndexRef.current.get(itemKey): undefined}
       extraData={extraData}
     />
   );

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,8 +37,9 @@ export type DraggableFlatListProps<T> = Modify<
     outerScrollOffset?: Animated.Node<number>;
     onAnimValInit?: (animVals: ReturnType<typeof useAnimatedValues>) => void;
     /**
-     * Whether the renderItem prop passed in doesn't need index to passed into
-     * the component. Can be used to improve performance. Defaults to true
+     * Defaults to true. If set to false, renderItem won't be passed the index
+     * of the item. This improves render performance by saving a re-render when
+     * items' indexes change
      */
     passIndexToRenderItem?: boolean;
   } & Partial<DefaultProps>

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,6 +36,11 @@ export type DraggableFlatListProps<T> = Modify<
     simultaneousHandlers?: React.Ref<any> | React.Ref<any>[];
     outerScrollOffset?: Animated.Node<number>;
     onAnimValInit?: (animVals: ReturnType<typeof useAnimatedValues>) => void;
+    /**
+     * Whether the renderItem prop passed in doesn't need index to passed into
+     * the component. Can be used to improve performance. Defaults to true
+     */
+    passIndexToRenderItem?: boolean;
   } & Partial<DefaultProps>
 >;
 


### PR DESCRIPTION
# Motivation

Performance for adding/removing an item from the `DraggableFlatList` was slow to the extent that it didn't feel like the user was getting instant feedback.

Wrapping `DraggableFlatListInner` with `typedMemo`/`React.memo`, reduced item component re-renders for this case. In its current state, whenever a change happened with one item component, it caused all of the item components to re-render.

When adding/removing an item from the list, the `index` prop of `MemoizedInner` in `src/components/RowItem.tsx` caused the components with indices **greater than** the item index being removed to re-render. `passIndexToRenderItem` can be used if the `index` field from the `params` passed into the `renderItem` prop isn't needed for rendering.

# Changes

- Added `passIndexToRenderItem` prop to `DraggableFlatListProps` and `RowItem`'s `Props`
- Wrapped `DraggableFlatListInner` with `typedMemo`

# Testing

Used `react-devtools` to measure performance.

| current state | typedMemo | typedMemo and passIndexToRenderItem |
| --- | --- | --- |
| 749.6ms| 526.1ms | 219.6ms |