### PR TITLE
removed unused ViewPropTypes

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,6 @@ import {
   FlatListProps,
   LayoutChangeEvent,
   StyleProp,
-  ViewPropTypes,
   ViewStyle,
 } from "react-native";
 import { useAnimatedValues } from "./context/animatedValueContext";


### PR DESCRIPTION
viewproptypes removed from react native 0.70+ so this library imported it but never used. This PR for version 4 beta actually. Not the RNReanimated v1 version. 
Could not figure it out the beta branch so opened for master. I can change it.