### PR TITLE
Updated README.md to include alternative if Reanimated can't be used

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To use swipeable list items in a DraggableFlatList see [React Native Swipeable I
 
 ## Install
 
-1. Follow installation instructions for [reanimated](https://github.com/kmagiera/react-native-reanimated) and [react-native-gesture-handler](https://github.com/kmagiera/react-native-gesture-handler). RNGH may require you to make changes to `MainActivity.java`. Be sure to [follow all Android instructions!](https://docs.swmansion.com/react-native-gesture-handler/docs/#android)
+1. Follow installation instructions for [reanimated](https://github.com/kmagiera/react-native-reanimated) and [react-native-gesture-handler](https://github.com/kmagiera/react-native-gesture-handler). RNGH may require you to make changes to `MainActivity.java`. Be sure to [follow all Android instructions!](https://docs.swmansion.com/react-native-gesture-handler/docs/#android). If using `react-native-reanimated` or `react-native-gesture-handler` is a problem, you could consider trying [react-native-draglist](https://github.com/fivecar/react-native-draglist/) instead. Its simple implementation has far less features and also doesn't render as smoothly, but it has no outside dependencies.
 2. Install this package using `npm` or `yarn`
 
 with `npm`:


### PR DESCRIPTION
`react-native-draggable-flatlist` is awesome, and I've used it in at least one other production project. But several years of `react-native-reanimated` crashes and hangs (which continue to be open issues in that project) caused me to need to back Reanimated out of my production codebase.

I wrote `react-native-draglist` for those who, like me, might need to pull out of Reanimated until it's more stable. The library isn't near as cool as `react-native-draggable-flatlist` (e.g. its animations are not as smooth, it doesn't support horizontal scrolling yet), but it has zero dependencies outside of `react-native` and `react`.

I'm hoping to offer that option here, in the docs, for others who might be stuck in a similar situation. The other packages out there without Reanimated are quite out of date, so `react-native-draglist` seemed the best alternative. Thanks!