### PR TITLE
Calling onRelease when user ends drag without moving their finger.

### DIFF
--- a/src/components/DraggableFlatList.tsx
+++ b/src/components/DraggableFlatList.tsx
@@ -234,6 +234,7 @@ function DraggableFlatListInner<T>(props: DraggableFlatListProps<T>) {
       if (cur !== prev && !cur) {
         const hasMoved = !!touchTranslate.value;
         if (!hasMoved && activeIndexAnim.value >= 0 && !disabled.value) {
+          runOnJS(onRelease)(activeIndexAnim.value);
           runOnJS(onDragEnd)({
             from: activeIndexAnim.value,
             to: spacerIndexAnim.value,


### PR DESCRIPTION
It would be helpful to call the onRelease callback in this case as well. For my particular use case I am using haptics for feedback and in this case of a user beginning a drag and not moving and then lifting their finger there was no good option for a haptic feedback. Putting the haptic on the onDragEnd has a delay which is not ideal.