### PR TITLE
Adding onPlaceholderIndexChange callback prop functionality

### DIFF
--- a/src/components/DraggableFlatList.tsx
+++ b/src/components/DraggableFlatList.tsx
@@ -225,6 +225,10 @@ function DraggableFlatListInner<T>(props: DraggableFlatListProps<T>) {
     }
   );
 
+  const onPlaceholderIndexChange = useStableCallback((index: number) => {
+    props.onPlaceholderIndexChange?.(index);
+  });
+
   // Handle case where user ends drag without moving their finger.
   useAnimatedReaction(
     () => {
@@ -242,6 +246,18 @@ function DraggableFlatListInner<T>(props: DraggableFlatListProps<T>) {
       }
     },
     [isTouchActiveNative, onDragEnd]
+  );
+
+  useAnimatedReaction(
+    () => {
+      return spacerIndexAnim.value;
+    },
+    (cur, prev) => {
+      if (cur !== prev && cur >= 0 && prev >= 0) {
+        runOnJS(onPlaceholderIndexChange)(cur)
+      }
+    },
+    [spacerIndexAnim]
   );
 
   const gestureDisabled = useSharedValue(false);


### PR DESCRIPTION
onPlaceholderIndexChange functionality was removed in the recent version but the prop remained. I have added functionality in for this already existing prop.

I am not sure how this used to function but it seemed to me to only call this when the index changes from the initial position. Perhaps this is not ideal? For my use case I wanted to use a haptic "click" as an item is dragged around and listening for this change while ignoring the starting index and ending index was/is most ideal.