### PR TITLE
Fix circular reference with Reanimated 3

### DIFF
--- a/src/context/animatedValueContext.tsx
+++ b/src/context/animatedValueContext.tsx
@@ -133,9 +133,10 @@ function useSetupAnimatedValues<T>() {
     );
   }, []);
 
+  const dragItemOverflow = props.dragItemOverflow;
   const hoverAnim = useDerivedValue(() => {
     if (activeIndexAnim.value < 0) return 0;
-    return props.dragItemOverflow
+    return dragItemOverflow
       ? touchPositionDiff.value
       : touchPositionDiffConstrained.value;
   }, []);


### PR DESCRIPTION
The Reanimated since version 3 captures entire objects to the worklet's closure, instead of capturing just single object property. However, this can cause problems when some objects contain circular references. To avoid issues, it is highly recommended to only pass objects that are as small as possible to the worklet closure.