### PR TITLE
more reliable event handling between pan gesture and FlatList

### DIFF
--- a/src/components/DraggableFlatList.tsx
+++ b/src/components/DraggableFlatList.tsx
@@ -39,6 +39,7 @@ type RNGHFlatListProps<T> = Animated.AnimateProps<
   FlatListProps<T> & {
     ref: React.Ref<FlatList<T>>;
     simultaneousHandlers?: React.Ref<any> | React.Ref<any>[];
+    waitFor?: React.Ref<unknown> | React.Ref<unknown>[];
   }
 >;
 
@@ -59,6 +60,7 @@ function DraggableFlatListInner<T>(props: DraggableFlatListProps<T>) {
     keyToIndexRef,
     propsRef,
     animationConfigRef,
+    panRef,
   } = useRefs<T>();
   const {
     activeCellOffset,
@@ -264,6 +266,7 @@ function DraggableFlatListInner<T>(props: DraggableFlatListProps<T>) {
   const gestureDisabled = useSharedValue(false);
 
   const panGesture = Gesture.Pan()
+    .withRef(panRef)
     .onBegin((evt) => {
       gestureDisabled.value = disabled.value;
       if (gestureDisabled.value) return;
@@ -386,6 +389,7 @@ function DraggableFlatListInner<T>(props: DraggableFlatListProps<T>) {
             keyExtractor={keyExtractor}
             onScroll={scrollHandler}
             scrollEventThrottle={16}
+            waitFor={panRef}
             simultaneousHandlers={props.simultaneousHandlers}
             removeClippedSubviews={false}
           />

--- a/src/components/DraggableFlatList.tsx
+++ b/src/components/DraggableFlatList.tsx
@@ -270,6 +270,7 @@ function DraggableFlatListInner<T>(props: DraggableFlatListProps<T>) {
     .onBegin((evt) => {
       gestureDisabled.value = disabled.value;
       if (gestureDisabled.value) return;
+      runOnJS(reset)();
       panGestureState.value = evt.state;
     })
     .onUpdate((evt) => {

--- a/src/context/refContext.tsx
+++ b/src/context/refContext.tsx
@@ -1,6 +1,6 @@
 import React, { useContext } from "react";
 import { useMemo, useRef } from "react";
-import { FlatList } from "react-native-gesture-handler";
+import { FlatList, GestureType } from "react-native-gesture-handler";
 import Animated, { WithSpringConfig } from "react-native-reanimated";
 import { DEFAULT_PROPS } from "../constants";
 import { useProps } from "./propsContext";
@@ -14,6 +14,7 @@ type RefContextValue<T> = {
   containerRef: React.RefObject<Animated.View>;
   flatlistRef: React.RefObject<FlatList<T>> | React.ForwardedRef<FlatList<T>>;
   scrollViewRef: React.RefObject<Animated.ScrollView>;
+  panRef: React.MutableRefObject<GestureType | undefined>;
 };
 const RefContext = React.createContext<RefContextValue<any> | undefined>(
   undefined
@@ -63,6 +64,7 @@ function useSetupRefs<T>({
   const flatlistRefInternal = useRef<FlatList<T>>(null);
   const flatlistRef = flatListRefProp || flatlistRefInternal;
   const scrollViewRef = useRef<Animated.ScrollView>(null);
+  const panRef = useRef<GestureType | undefined>(undefined);
 
   // useEffect(() => {
   //   // This is a workaround for the fact that RN does not respect refs passed in
@@ -85,6 +87,7 @@ function useSetupRefs<T>({
       keyToIndexRef,
       propsRef,
       scrollViewRef,
+      panRef,
     }),
     []
   );


### PR DESCRIPTION
According to the issue reported in https://github.com/computerjazz/react-native-draggable-flatlist/issues/467, this fix improves (at least in my case) the propagation of the events between the pan gesture and the FlatList scroll event avoiding in fast panning the cancelation of the pan gesture in favor of the FlatList scroll event.
Additionally, there are cases where visual gaps occur at the first offset, so add the reset call in the begin.