### PR TITLE
Prevent initial scroll jump in NestedDraggableFlatlist

### DIFF
--- a/src/context/animatedValueContext.tsx
+++ b/src/context/animatedValueContext.tsx
@@ -89,6 +89,19 @@ function useSetupAnimatedValues<T>() {
     return isTouchActiveNative.value && activeIndexAnim.value >= 0;
   }, []);
 
+  useAnimatedReaction(
+    () => {
+      return outerScrollOffset.value;
+    },
+    (cur, prev) => {
+      if (isDraggingCell.value) {
+        return;
+      }
+      outerScrollInit.value = cur;
+    },
+    [outerScrollInit, isDraggingCell]
+  );
+
   const autoScrollDistance = useDerivedValue(() => {
     if (!isDraggingCell.value) return 0;
     const innerScrollDiff = scrollOffset.value - scrollInit.value;


### PR DESCRIPTION
There is a small glitch when you try to drag n drop an item after performing an initial scroll.
This seems to occurs only in `NestedDraggableFlatList`.
The outer scroll position is not updated after doing a scroll, which causes a "jump".
It should fix this issue : https://github.com/computerjazz/react-native-draggable-flatlist/issues/509