### PR TITLE
Make `data` prop optionally readonly

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -25,7 +25,7 @@ type DefaultProps = Readonly<typeof DEFAULT_PROPS>;
 export type DraggableFlatListProps<T> = Modify<
   FlatListProps<T>,
   {
-    data: T[];
+    data: T[] | readonly T[];
     activationDistance?: number;
     animationConfig?: Partial<WithSpringConfig>;
     autoscrollSpeed?: number;


### PR DESCRIPTION
The `data` prop is specifically not `readonly` which means that the results of a selector can't be passed to it.

Is there any potential downside to enabling readonly props here? The underlying flatlist prop is `data: ?$ReadOnlyArray<ItemT>,` and I hope this library isn't trying to modify the mutable prop value or anything.

Related: 
- https://github.com/computerjazz/react-native-draggable-flatlist/issues/190