### PR TITLE
fix: glitching when reordering items

### DIFF
--- a/src/components/CellRendererComponent.tsx
+++ b/src/components/CellRendererComponent.tsx
@@ -4,7 +4,6 @@ import {
   LayoutChangeEvent,
   MeasureLayoutOnSuccessCallback,
   StyleProp,
-  StyleSheet,
   ViewStyle,
 } from "react-native";
 import Animated, {
@@ -163,11 +162,7 @@ function CellRendererComponent<T>(props: Props<T>) {
           ? itemLayoutAnimation
           : undefined
       }
-      style={[
-        props.style,
-        baseStyle,
-        activeKey ? animStyle : styles.zeroTranslate,
-      ]}
+      style={[props.style, baseStyle, animStyle]}
       pointerEvents={activeKey ? "none" : "auto"}
     >
       <CellProvider isActive={isActive}>{children}</CellProvider>
@@ -176,12 +171,6 @@ function CellRendererComponent<T>(props: Props<T>) {
 }
 
 export default typedMemo(CellRendererComponent);
-
-const styles = StyleSheet.create({
-  zeroTranslate: {
-    transform: [{ translateX: 0 }, { translateY: 0 }],
-  },
-});
 
 declare global {
   namespace NodeJS {

--- a/src/components/DraggableFlatList.tsx
+++ b/src/components/DraggableFlatList.tsx
@@ -6,7 +6,12 @@ import React, {
   useRef,
   useState,
 } from "react";
-import { ListRenderItem, FlatListProps, LayoutChangeEvent } from "react-native";
+import {
+  ListRenderItem,
+  FlatListProps,
+  LayoutChangeEvent,
+  InteractionManager,
+} from "react-native";
 import {
   FlatList,
   Gesture,
@@ -20,7 +25,7 @@ import Animated, {
   withSpring,
 } from "react-native-reanimated";
 import CellRendererComponent from "./CellRendererComponent";
-import { DEFAULT_PROPS, isWeb } from "../constants";
+import { DEFAULT_PROPS } from "../constants";
 import PlaceholderItem from "./PlaceholderItem";
 import RowItem from "./RowItem";
 import { DraggableFlatListProps } from "../types";
@@ -114,6 +119,9 @@ function DraggableFlatListInner<T>(props: DraggableFlatListProps<T>) {
   if (dataHasChanged) {
     // When data changes make sure `activeKey` is nulled out in the same render pass
     activeKey = null;
+    InteractionManager.runAfterInteractions(() => {
+      reset();
+    });
   }
 
   useEffect(() => {
@@ -221,7 +229,8 @@ function DraggableFlatListInner<T>(props: DraggableFlatListProps<T>) {
       }
 
       onDragEnd?.({ from, to, data: newData });
-      reset();
+
+      setActiveKey(null);
     }
   );
 


### PR DESCRIPTION
Fix for issue: https://github.com/computerjazz/react-native-draggable-flatlist/issues/572

This PR fixes an issue where drag state (`activeKey`, animated values) wasn’t correctly reset when the data prop changed. The previous implementation mutated `activeKey` directly during render without calling `reset()`, leaving shared animated values stale and potentially causing gesture bugs or UI inconsistencies. Having the `reset()` called too earlier made the UI glitch as it was rendering faster than the state change were processed.

We now defer the `reset()` call using `InteractionManager.runAfterInteractions()` to safely clear both React and Reanimated state after the render pass.

Why this matters:
- Prevents visual glitches and inconsistent behaviour during/after drag
- Ensures gesture state is fully reset between data updates
- Avoids state mutation during render
