### PR TITLE
constrain dragging to within list, not footer

### DIFF
--- a/src/components/DraggableFlatList.tsx
+++ b/src/components/DraggableFlatList.tsx
@@ -171,11 +171,11 @@ function DraggableFlatListInner<T>({ListFooterComponent, ...props}: DraggableFla
     props.onContainerLayout?.({ layout, containerRef });
   };
 
-  // make height of footer available for use in drag contraints
+  // make size of footer available for use in drag contraints
   const onFooterLayout = ({
     nativeEvent: { layout },
   }: LayoutChangeEvent) => {
-    footerSize.value = layout.height
+    footerSize.value = props.horizontal ? layout.width : layout.height
   };
 
 
@@ -376,13 +376,14 @@ function DraggableFlatListInner<T>({ListFooterComponent, ...props}: DraggableFla
   });
 
   // Wrap the provided ListFooterComponent to add an onLayout
-  const wrappedListFooterComponent = 
-  <Animated.View 
-    style={props.ListFooterComponentStyle}
-    onLayout={onFooterLayout}
-    >
-      {ListFooterComponent}
-  </Animated.View>
+  const wrappedListFooterComponent = ListFooterComponent ?
+    <Animated.View 
+      style={props.ListFooterComponentStyle}
+      onLayout={onFooterLayout}
+      >
+        {ListFooterComponent}
+    </Animated.View>
+  : undefined
 
   return (
     <DraggableFlatListProvider

--- a/src/components/DraggableFlatList.tsx
+++ b/src/components/DraggableFlatList.tsx
@@ -56,7 +56,7 @@ const AnimatedFlatList = (Animated.createAnimatedComponent(
   FlatList
 ) as unknown) as <T>(props: RNGHFlatListProps<T>) => React.ReactElement;
 
-function DraggableFlatListInner<T>(props: DraggableFlatListProps<T>) {
+function DraggableFlatListInner<T>({ListFooterComponent, ...props}: DraggableFlatListProps<T>) {
   const {
     cellDataRef,
     containerRef,
@@ -70,6 +70,7 @@ function DraggableFlatListInner<T>(props: DraggableFlatListProps<T>) {
     activeCellSize,
     activeIndexAnim,
     containerSize,
+    footerHeight,
     scrollOffset,
     scrollViewSize,
     spacerIndexAnim,
@@ -169,6 +170,14 @@ function DraggableFlatListInner<T>(props: DraggableFlatListProps<T>) {
     containerSize.value = props.horizontal ? width : height;
     props.onContainerLayout?.({ layout, containerRef });
   };
+
+  // make height of footer available for use in drag contraints
+  const onFooterLayout = ({
+    nativeEvent: { layout },
+  }: LayoutChangeEvent) => {
+    footerHeight.value = layout.height
+  };
+
 
   const onListContentSizeChange = (w: number, h: number) => {
     scrollViewSize.value = props.horizontal ? w : h;
@@ -366,6 +375,15 @@ function DraggableFlatListInner<T>(props: DraggableFlatListProps<T>) {
     props.onViewableItemsChanged?.(info);
   });
 
+  // Wrap the provided ListFooterComponent to add an onLayout
+  const wrappedListFooterComponent = 
+  <Animated.View 
+    style={props.ListFooterComponentStyle}
+    onLayout={onFooterLayout}
+    >
+      {ListFooterComponent}
+  </Animated.View>
+
   return (
     <DraggableFlatListProvider
       activeKey={activeKey}
@@ -397,6 +415,7 @@ function DraggableFlatListInner<T>(props: DraggableFlatListProps<T>) {
             scrollEventThrottle={16}
             simultaneousHandlers={props.simultaneousHandlers}
             removeClippedSubviews={false}
+            ListFooterComponent={wrappedListFooterComponent}
           />
           {!!props.onScrollOffsetChange && (
             <ScrollOffsetListener

--- a/src/components/DraggableFlatList.tsx
+++ b/src/components/DraggableFlatList.tsx
@@ -70,7 +70,7 @@ function DraggableFlatListInner<T>({ListFooterComponent, ...props}: DraggableFla
     activeCellSize,
     activeIndexAnim,
     containerSize,
-    footerHeight,
+    footerSize,
     scrollOffset,
     scrollViewSize,
     spacerIndexAnim,
@@ -175,7 +175,7 @@ function DraggableFlatListInner<T>({ListFooterComponent, ...props}: DraggableFla
   const onFooterLayout = ({
     nativeEvent: { layout },
   }: LayoutChangeEvent) => {
-    footerHeight.value = layout.height
+    footerSize.value = layout.height
   };
 
 

--- a/src/context/animatedValueContext.tsx
+++ b/src/context/animatedValueContext.tsx
@@ -60,7 +60,7 @@ function useSetupAnimatedValues<T>() {
   const activeCellSize = useSharedValue(0); // Height or width of acctive cell
   const activeCellOffset = useSharedValue(0); // Distance between active cell and edge of container
 
-  const footerSize = useSharedValue(0); // Height of list footer
+  const footerSize = useSharedValue(0);
   const scrollOffset = useSharedValue(0);
   const scrollInit = useSharedValue(0);
 

--- a/src/context/animatedValueContext.tsx
+++ b/src/context/animatedValueContext.tsx
@@ -60,6 +60,7 @@ function useSetupAnimatedValues<T>() {
   const activeCellSize = useSharedValue(0); // Height or width of acctive cell
   const activeCellOffset = useSharedValue(0); // Distance between active cell and edge of container
 
+  const footerHeight = useSharedValue(0); // Height of list footer
   const scrollOffset = useSharedValue(0);
   const scrollInit = useSharedValue(0);
 
@@ -118,7 +119,7 @@ function useSetupAnimatedValues<T>() {
 
     const maxTranslateNegative = -activeCellOffset.value;
     const maxTranslatePositive =
-      scrollViewSize.value - (activeCellOffset.value + activeCellSize.value);
+      scrollViewSize.value - (activeCellOffset.value + activeCellSize.value + footerHeight.value);
 
     // Only constrain the touch position while the finger is on the screen. This allows the active cell
     // to snap above/below the fold once let go, if the drag ends at the top/bottom of the screen.
@@ -175,6 +176,7 @@ function useSetupAnimatedValues<T>() {
       placeholderOffset,
       resetTouchedCell,
       scrollOffset,
+      footerHeight,
       scrollViewSize,
       spacerIndexAnim,
       touchPositionDiff,
@@ -198,6 +200,7 @@ function useSetupAnimatedValues<T>() {
       placeholderOffset,
       resetTouchedCell,
       scrollOffset,
+      footerHeight,
       scrollViewSize,
       spacerIndexAnim,
       touchPositionDiff,

--- a/src/context/animatedValueContext.tsx
+++ b/src/context/animatedValueContext.tsx
@@ -60,7 +60,7 @@ function useSetupAnimatedValues<T>() {
   const activeCellSize = useSharedValue(0); // Height or width of acctive cell
   const activeCellOffset = useSharedValue(0); // Distance between active cell and edge of container
 
-  const footerHeight = useSharedValue(0); // Height of list footer
+  const footerSize = useSharedValue(0); // Height of list footer
   const scrollOffset = useSharedValue(0);
   const scrollInit = useSharedValue(0);
 
@@ -119,7 +119,7 @@ function useSetupAnimatedValues<T>() {
 
     const maxTranslateNegative = -activeCellOffset.value;
     const maxTranslatePositive =
-      scrollViewSize.value - (activeCellOffset.value + activeCellSize.value + footerHeight.value);
+      scrollViewSize.value - (activeCellOffset.value + activeCellSize.value + footerSize.value);
 
     // Only constrain the touch position while the finger is on the screen. This allows the active cell
     // to snap above/below the fold once let go, if the drag ends at the top/bottom of the screen.
@@ -176,7 +176,7 @@ function useSetupAnimatedValues<T>() {
       placeholderOffset,
       resetTouchedCell,
       scrollOffset,
-      footerHeight,
+      footerSize,
       scrollViewSize,
       spacerIndexAnim,
       touchPositionDiff,
@@ -200,7 +200,7 @@ function useSetupAnimatedValues<T>() {
       placeholderOffset,
       resetTouchedCell,
       scrollOffset,
-      footerHeight,
+      footerSize,
       scrollViewSize,
       spacerIndexAnim,
       touchPositionDiff,

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,6 +52,7 @@ export type DraggableFlatListProps<T> = Modify<
       layout: LayoutChangeEvent["nativeEvent"]["layout"];
       containerRef: React.RefObject<Animated.View>;
     }) => void;
+    ListFooterComponent?: React.ReactElement;
   } & Partial<DefaultProps>
 >;
 


### PR DESCRIPTION
When constraining dragging to within the list, take into account the height of the list footer, and don't allow items to be dragged into the footer.